### PR TITLE
Add option to split the fused expert weight into nn.linears and save with fused weights 

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2956,11 +2956,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             else:
                 device_map = {"": device_map}
 
-        if device_map is not None:
-            if low_cpu_mem_usage is None:
-                low_cpu_mem_usage = True
-            elif not low_cpu_mem_usage:
-                raise ValueError("Passing along a `device_map` requires `low_cpu_mem_usage=True`")
+        # if device_map is not None:
+        #     if low_cpu_mem_usage is None:
+        #         low_cpu_mem_usage = True
+        #     elif not low_cpu_mem_usage:
+        #         raise ValueError("Passing along a `device_map` requires `low_cpu_mem_usage=True`")
 
         if low_cpu_mem_usage:
             if is_deepspeed_zero3_enabled():
@@ -3821,21 +3821,22 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             output_embeddings._is_hf_initialized = True
             else:
                 not_initialized_submodules = dict(model.named_modules())
-            # This will only initialize submodules that are not marked as initialized by the line above.
-            if is_deepspeed_zero3_enabled() and not is_quantized:
-                import deepspeed
 
-                not_initialized_parameters = list(
-                    set(
-                        itertools.chain.from_iterable(
-                            submodule.parameters(recurse=False) for submodule in not_initialized_submodules.values()
-                        )
-                    )
-                )
-                with deepspeed.zero.GatheredParameters(not_initialized_parameters, modifier_rank=0):
-                    model.apply(model._initialize_weights)
-            else:
-                model.apply(model._initialize_weights)
+            # This will only initialize submodules that are not marked as initialized by the line above.
+            # if is_deepspeed_zero3_enabled():
+            #     import deepspeed
+
+            #     not_initialized_parameters = list(
+            #         set(
+            #             itertools.chain.from_iterable(
+            #                 submodule.parameters(recurse=False) for submodule in not_initialized_submodules.values()
+            #             )
+            #         )
+            #     )
+            #     with deepspeed.zero.GatheredParameters(not_initialized_parameters, modifier_rank=0):
+            #         model.apply(model._initialize_weights)
+            # else:
+            #     model.apply(model._initialize_weights)
 
         # Set some modules to fp32 if any
         if keep_in_fp32_modules is not None:

--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -119,6 +119,7 @@ class DbrxFFNConfig(PretrainedConfig):
         moe_normalize_expert_weights: Optional[float] = 1,
         uniform_expert_assignment: bool = False,
         split_expert_weights: bool = False,
+        fuse_expert_weights_on_save: bool = False,
         **kwargs: Any,
     ):
         super().__init__()
@@ -133,6 +134,7 @@ class DbrxFFNConfig(PretrainedConfig):
         self.moe_normalize_expert_weights = moe_normalize_expert_weights
         self.uniform_expert_assignment = uniform_expert_assignment
         self.split_expert_weights = split_expert_weights
+        self.fuse_expert_weights_on_save = fuse_expert_weights_on_save
 
         for k in ['model_type']:
             if k in kwargs:

--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -118,6 +118,7 @@ class DbrxFFNConfig(PretrainedConfig):
         moe_loss_weight: float = 0.01,
         moe_normalize_expert_weights: Optional[float] = 1,
         uniform_expert_assignment: bool = False,
+        split_expert_weights: bool = False,
         **kwargs: Any,
     ):
         super().__init__()
@@ -131,6 +132,7 @@ class DbrxFFNConfig(PretrainedConfig):
         self.moe_loss_weight = moe_loss_weight
         self.moe_normalize_expert_weights = moe_normalize_expert_weights
         self.uniform_expert_assignment = uniform_expert_assignment
+        self.split_expert_weights = split_expert_weights
 
         for k in ['model_type']:
             if k in kwargs:

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -896,6 +896,7 @@ class DbrxFFN(nn.Module):
             moe_num_experts=ffn_config.moe_num_experts,
             ffn_act_fn=ffn_config.ffn_act_fn,
             split_expert_weights=ffn_config.split_expert_weights,
+            fuse_expert_weights_on_save=ffn_config.fuse_expert_weights_on_save,
         )
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -1325,6 +1326,7 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
         self.num_experts = config.ffn_config.moe_num_experts
         self.num_experts_per_tok = config.ffn_config.moe_top_k
         self.split_expert_weights = config.ffn_config.split_expert_weights
+        self.fuse_expert_weights_on_save = config.ffn_config.fuse_expert_weights_on_save
 
         def _load_state_dict_pre_hook(state_dict, *args, **kwargs):
             new_state_dict = type(state_dict)()
@@ -1383,6 +1385,8 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
 
         if config.ffn_config.split_expert_weights:
             self._register_load_state_dict_pre_hook(_load_state_dict_pre_hook)
+
+        if config.ffn_config.fuse_expert_weights_on_save:
             self._register_state_dict_hook(_state_dict_hook)
 
         # Initialize weights and apply final processing

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -896,7 +896,6 @@ class DbrxFFN(nn.Module):
             moe_num_experts=ffn_config.moe_num_experts,
             ffn_act_fn=ffn_config.ffn_act_fn,
             split_expert_weights=ffn_config.split_expert_weights,
-            fuse_expert_weights_on_save=ffn_config.fuse_expert_weights_on_save,
         )
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -1327,7 +1327,6 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
         self.split_expert_weights = config.ffn_config.split_expert_weights
 
         def _load_state_dict_pre_hook(state_dict, *args, **kwargs):
-            """Redefine module saved as DbrxExpertGLU."""
             new_state_dict = type(state_dict)()
             ws = ["w1", "v1", "w2"]
             n_layers = self.config.n_layers
@@ -1339,7 +1338,6 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
                     for w in ws:
                         target_k = ".".join(["transformer.blocks", str(idx), "ffn.experts.mlp", w])
                         if k == target_k:
-                            print(f"Loading {target_k} from state_dict, {v.shape=}")
                             ws_reshaped =v.view(moe_num_experts, ffn_hidden_size,
                                                             hidden_size)
                             if w == "w2":

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -796,13 +796,20 @@ class DbrxExpertGLU(nn.Module):
 class DbrxExperts(nn.Module):
 
     def __init__(self, hidden_size: int, ffn_hidden_size: int,
-                 moe_num_experts: int, ffn_act_fn: dict):
+                 moe_num_experts: int, ffn_act_fn: dict, split_expert_weights: bool):
         super().__init__()
         self.moe_num_experts = moe_num_experts
-        self.mlp = DbrxExpertGLU(hidden_size=hidden_size,
-                                 ffn_hidden_size=ffn_hidden_size,
-                                 moe_num_experts=moe_num_experts,
-                                 ffn_act_fn=ffn_act_fn)
+        if split_expert_weights:
+            self.mlp = DbrxExpertGLUSplit(hidden_size=hidden_size,
+                                    ffn_hidden_size=ffn_hidden_size,
+                                    moe_num_experts=moe_num_experts,
+                                    ffn_act_fn=ffn_act_fn)
+
+        else:
+            self.mlp = DbrxExpertGLU(hidden_size=hidden_size,
+                                    ffn_hidden_size=ffn_hidden_size,
+                                    moe_num_experts=moe_num_experts,
+                                    ffn_act_fn=ffn_act_fn)
 
     def forward(self, x: torch.Tensor, weights: torch.Tensor,
                 top_weights: torch.Tensor,
@@ -831,6 +838,42 @@ class DbrxExperts(nn.Module):
         out = out.reshape(bsz, q_len, hidden_size)
         return out
 
+class DbrxExpertGLUSplit(nn.Module):
+
+    def __init__(self, hidden_size: int, ffn_hidden_size: int, moe_num_experts: int, ffn_act_fn: dict):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.ffn_hidden_size = ffn_hidden_size
+        self.moe_num_experts = moe_num_experts
+
+        self.w1 = nn.ModuleList([nn.Linear(
+            in_features=hidden_size,
+            out_features=ffn_hidden_size,
+            bias=False,
+        ) for _ in range(self.moe_num_experts)])
+
+        self.v1 = nn.ModuleList([nn.Linear(
+            in_features=hidden_size,
+            out_features=ffn_hidden_size,
+            bias=False,
+        ) for _ in range(self.moe_num_experts)])
+
+
+        self.w2 = nn.ModuleList([nn.Linear(
+            in_features=ffn_hidden_size,
+            out_features=hidden_size,
+            bias=False,
+        ) for _ in range(self.moe_num_experts)])
+
+        self.activation_fn = resolve_ffn_act_fn(ffn_act_fn)
+
+    def forward(self, x: torch.Tensor, expert_idx: int) -> torch.Tensor:
+        x1 = self.w1[expert_idx](x)
+        x2 = self.v1[expert_idx](x)
+        x1 = self.activation_fn(x1)
+        x1 = x1 * x2
+        x1 = self.w2[expert_idx](x1)
+        return x1
 
 class DbrxFFN(nn.Module):
 
@@ -852,6 +895,7 @@ class DbrxFFN(nn.Module):
             ffn_hidden_size=ffn_config.ffn_hidden_size,
             moe_num_experts=ffn_config.moe_num_experts,
             ffn_act_fn=ffn_config.ffn_act_fn,
+            split_expert_weights=ffn_config.split_expert_weights,
         )
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -1280,6 +1324,34 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
         self.router_aux_loss_coef = config.router_aux_loss_coef
         self.num_experts = config.ffn_config.moe_num_experts
         self.num_experts_per_tok = config.ffn_config.moe_top_k
+        self.split_expert_weights = config.ffn_config.split_expert_weights
+
+        def _load_state_dict_pre_hook(state_dict, *args, **kwargs):
+            """Redefine module saved as DbrxExpertGLU."""
+            new_state_dict = type(state_dict)()
+            ws = ["w1", "v1", "w2"]
+            n_layers = self.config.n_layers
+            moe_num_experts = self.config.ffn_config.moe_num_experts
+            ffn_hidden_size = self.config.ffn_config.ffn_hidden_size
+            hidden_size = self.config.d_model
+            for k, v in state_dict.items():
+                for idx in range(n_layers):
+                    for w in ws:
+                        target_k = ".".join(["transformer.blocks", str(idx), "ffn.experts.mlp", w])
+                        if k == target_k:
+                            print(f"Loading {target_k} from state_dict, {v.shape=}")
+                            ws_reshaped =v.view(moe_num_experts, ffn_hidden_size,
+                                                            hidden_size)
+                            if w == "w2":
+                                ws_reshaped = ws_reshaped.transpose(-1, -2)
+                            for idx in range(moe_num_experts):
+                                new_k = '.'.join([k, str(idx), 'weight'])
+                                new_state_dict[new_k] = ws_reshaped[idx]
+
+            state_dict.update(new_state_dict)
+
+        if config.ffn_config.split_expert_weights:
+            self._register_load_state_dict_pre_hook(_load_state_dict_pre_hook)
 
         # Initialize weights and apply final processing
         self.post_init()

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -1358,21 +1358,15 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
             for idx in range(n_layers):
                 for w in ["w1", "v1", "w2"]:
                     ws = []
-
                     key =  f'transformer.blocks.{idx}.ffn.experts.mlp.{w}'
-
                     new_key = f'transformer.blocks.{idx}.ffn.experts.mlp.{w}'
-                    if key.startswith('_fsdp_wrapped_module.'):
-                        new_key = '_fsdp_wrapped_module.' + new_key
 
                     for expert_idx in range(moe_num_experts):
                         inner_key = key + f'.{expert_idx}.weight'
                         if inner_key not in state_dict:
                             inner_key = '_fsdp_wrapped_module.' + inner_key
-
                         if inner_key not in state_dict:
                             continue
-
                         ws.append(state_dict[inner_key])
 
                     if len(ws) > 0 and isinstance(ws[0], torch.Tensor):


### PR DESCRIPTION
This PR adds
1.  `split_expert_weights` to control whether the HF checkpoint is loaded into `DbrxExpertGLU`(with fused expert weights) or `DbrxExpertGLUSplit` (with split expert weights and defined as sequence of nn.linear)
2. `fuse_expert_weights_on_save` to control wether the model state_dict is saved as fused expert weights or not

Tests:
(1) saving sharded checkpoints keeps the linears in the state dict, checkpoint can be resumed from
https://gist.github.com/cli99/6d18891d3e88a9641ed6c883c1decd00
(2) saved full checkpoints remaps to fused, checkpoint can be resumed from
https://gist.github.com/cli99/dc12ce4e87ca598d58e75d6960eb3c66
(3) saving hf checkpoints remaps to fused