### PR TITLE
Add state dict hooks

### DIFF
--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -112,6 +112,8 @@ class DbrxFFNConfig(PretrainedConfig):
         moe_loss_weight: float = 0.01,
         moe_normalize_expert_weights: Optional[float] = 1.0,
         uniform_expert_assignment: bool = False,
+        split_expert_weights: bool = False,
+        fuse_expert_weights_on_save: bool = False,
         **kwargs: Any,
     ):
         super().__init__()
@@ -125,6 +127,8 @@ class DbrxFFNConfig(PretrainedConfig):
         self.moe_loss_weight = moe_loss_weight
         self.moe_normalize_expert_weights = moe_normalize_expert_weights
         self.uniform_expert_assignment = uniform_expert_assignment
+        self.split_expert_weights = split_expert_weights
+        self.fuse_expert_weights_on_save = fuse_expert_weights_on_save
 
         for k in ["model_type"]:
             if k in kwargs:


### PR DESCRIPTION
This PR adds
1.  `split_expert_weights` to control whether the HF checkpoint is loaded into `DbrxExpertGLU`(with fused expert weights) or `DbrxExpertGLUSplit` (with split expert weights and defined as sequence of nn.linear)
2. `fuse_expert_weights_on_save` to control wether the model state_dict is saved as fused expert weights or not
We [register a load_state_dict_pre_hook ](https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/module.py#L421C5-L421C31)to `DbrxForCausalLM` to do the `state_dict` remapping. The hook is called before loading `state_dict` into `self`. 

Example usage:
```
        config = AutoConfig.from_pretrained(args.name_or_path,
                                            **from_pretrained_kwargs)
       #  config.ffn_config.split_expert_weights == True to load fused expert weights into split nn.linears
       #  config.ffn_config.fuse_expert_weights_on_save == True if saving model state dict back into fused expert weight
        model = AutoModelForCausalLM.from_pretrained(args.name_or_path,
                                                     config=config,
                                                     torch_dtype=model_dtype,
                                                     device_map='auto',
                                                     low_cpu_mem_usage=False,
                                                     **from_pretrained_kwargs)
```
Changes in modeling_utils.py:
1. For `model._load_state_dict` and `load_state_dict_pre_hook` on the model to be invoked, we reply on [this path](https://github.com/huggingface/transformers/blob/4d8427f/src/transformers/modeling_utils.py#L4008) and need to use `low_cpu_mem_usage`. We don't overwrite `low_cpu_mem_usage` when `device_map == 'auto'`, otherwise [the other code path](https://github.com/huggingface/transformers/blob/4d8427f/src/transformers/modeling_utils.py#L3981) is taken and does not trigger the `load_state_dict_pre_hook`
2. [This](https://github.com/huggingface/transformers/blob/4d8427f/src/transformers/modeling_utils.py#L3838) causes hanging if we configure the model with `split_expert_weights`. So we bypass it if using `split_expert_weights`.